### PR TITLE
rails: upgrade redirect_to to use allow_other_host

### DIFF
--- a/lib/casclient/frameworks/rails/filter.rb
+++ b/lib/casclient/frameworks/rails/filter.rb
@@ -218,7 +218,7 @@ module CASClient
             st = controller.session[:cas_last_valid_ticket]
             @@client.ticket_store.cleanup_service_session_lookup(st) if st
             controller.send(:reset_session)
-            controller.send(:redirect_to, client.logout_url(referer))
+            controller.send(:redirect_to, client.logout_url(referer), allow_other_host: true)
           end
           
           def unauthorized!(controller, vr = nil)
@@ -271,7 +271,7 @@ module CASClient
             controller.session[:previous_redirect_to_cas] = Time.now
             
             log.debug("Redirecting to #{redirect_url.inspect}")
-            controller.send(:redirect_to, redirect_url)
+            controller.send(:redirect_to, redirect_url, allow_other_host: true)
           end
           
           private


### PR DESCRIPTION
Rails 7.0's default configuration is that redirect_to is no longer allowed to redirect to other hosts or subdomains. Since CAS fundamentally relies on this sort of thing, this updates the redirect_to calls to use allow_other_host: true.

This was causing MANY test failures in m3.